### PR TITLE
handle multiple conditions in api/clues

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -15,23 +15,22 @@ class ApiController < ApplicationController
 			format.json { render :json => @result.to_json(:include => :category) }
 		end	
 	end
-	
-	def clues
 
-		conditions = []
-		conditions.push "value = ?", params[:value]  if params[:value].present?
+	def clues
+		clues = Clue
+		clues = clues.where("value = ?", params[:value])  if params[:value].present?
 		if(params[:min_date].present? && params[:max_date].present?)
-			conditions.push "airdate between ? AND ?", Chronic.parse(params[:min_date]), Chronic.parse(params[:max_date]) 
+			clues = clues.where("airdate between ? AND ?", Chronic.parse(params[:min_date]), Chronic.parse(params[:max_date]))
 		else
-			conditions.push "airdate < ?", Chronic.parse(params[:min_date]) if params[:min_date].present?
-			conditions.push "airdate > ?", Chronic.parse(params[:max_date]) if params[:max_date].present?
+			clues = clues.where("airdate < ?", Chronic.parse(params[:min_date])) if params[:min_date].present?
+			clues = clues.where("airdate > ?", Chronic.parse(params[:max_date])) if params[:max_date].present?
 		end
 
-		conditions.push "category_id = ?", params[:category] if params[:category].present?	
+		clues = clues.where("category_id = ?", params[:category]) if params[:category].present?
 		offset = params[:offset].present? ? params[:offset] : 0
 
-		@result = Clue.all(:conditions => conditions, :limit => 100, :offset => offset )
-		
+		@result = clues.limit(100).offset(offset)
+
 		respond_to do |format|
 			format.json { render :json => @result.to_json(:include => :category) }
 		end


### PR DESCRIPTION
Awesome project! I've been working on an [Ember front-end](https://github.com/coleww/jparty) to this dataset/API, but I noticed that the clues API doesn't seem to like getting multiple conditions.

if I visit a path like: `/api/clues?category=1633&value=400`

then i get this error: ```ActiveRecord::PreparedStatementInvalid in ApiController#clues
wrong number of bind variables (3 for 1) in: value = ?```

because Rails seems to want something like this: `:conditions => ['value = ? and category = ?', 'foo', 'bar']`

I modified the query to chain a series of `where` statements rather than build up the conditions array
