### PR TITLE
Adding HipChat web hook repo link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ View a working demo at http://jservice.io
 ###jService in the wild
 * [jService Twitter Bot](http://twitter.com/jservicebot)
 * [TrebekBot for Slack](https://github.com/gesteves/trebekbot)
-
+* [Trebek for HipChat](https://github.com/yanigisawa/hip-trebek)


### PR DESCRIPTION
I recently finished writing a port of the slack bot for HipChat. I noticed you had a section of your readme that included bots "in the wild", so I thought I'd submit this to you to add it to your repo's readme.