### PR TITLE
Fixing Empty Question records

### DIFF
--- a/lib/tasks/get_latest.rake
+++ b/lib/tasks/get_latest.rake
@@ -66,23 +66,20 @@
 		  			var_answer = answermatch.captures[0].to_s
 		 
 		  			#puts var_answer
+					var_question = q.css('.clue_text').text()
+					index =	q.xpath('count(preceding-sibling::*)').to_i
+					var_category = categoryArr[index]
+					var_value = q.css('.clue_value').text[/[0-9\.]+/]
+
+					newClue = Clue.where(
+						:question => var_question,
+						:answer => var_answer,
+						:category => var_category,
+						:value => var_value,
+						:airdate => var_airdate,
+						:game_id => gid
+					).first_or_create
 		  		end
-		
-		  		var_question = q.css('.clue_text').text()
-		  		index =	q.xpath('count(preceding-sibling::*)').to_i
-		  		var_category = categoryArr[index]
-		  		var_value = q.css('.clue_value').text[/[0-9\.]+/]
-		  		
-		  		newClue = Clue.where(
-		  			:question => var_question,
-		  			:answer => var_answer,
-		  			:category => var_category,
-		  			:value => var_value,
-		  			:airdate => var_airdate,
-		  			:game_id => gid
-		  		).first_or_create
-		  		
-		  		
 		  	end
 		 end #each
 	  end #if


### PR DESCRIPTION
The rake task correctly detects whether or not the HTML table cell contains the answer, however it will always write a record to the clues table, even if the question and answer are empty. If this is the desired behavior (e.g. to accurately count the number of clues for a given category), reject this PR.

However, it seems that if this data set is to be used by bots or other applications for impromptu jeopardy games, we'd only care about clues that we can actually respond to. 