### PR TITLE
Fix comparison operator where only min_date OR max_date is applied

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -33,8 +33,8 @@ class ApiController < ApplicationController
     if(params[:min_date].present? && params[:max_date].present?)
       clues = clues.where("airdate between ? AND ?", Chronic.parse(params[:min_date]), Chronic.parse(params[:max_date]))
     else
-      clues = clues.where("airdate < ?", Chronic.parse(params[:min_date])) if params[:min_date].present?
-      clues = clues.where("airdate > ?", Chronic.parse(params[:max_date])) if params[:max_date].present?
+      clues = clues.where("airdate > ?", Chronic.parse(params[:min_date])) if params[:min_date].present?
+      clues = clues.where("airdate < ?", Chronic.parse(params[:max_date])) if params[:max_date].present?
     end
 
     clues = clues.where("category_id = ?", params[:category]) if params[:category].present?


### PR DESCRIPTION
In reference to https://github.com/sottenad/jService/issues/43 - 

Currently, the clues endpoint does not work correctly when one of these operators is applied because -

1. On min_date, we are doing `airdate < ?`
2. On max_date, we are doing `airdate > ?`

Where are the conditions should be flipped, i.e 

1. more than min_date
2. less than max_date

The PR fixes this problem.