### PR TITLE
Change `TABLESAMPLE` query for getting a random clue to sample 100% of the table instead of 1%

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -9,7 +9,7 @@ class ApiController < ApplicationController
     end
 
     
-    @result = Clue.from('"clues" TABLESAMPLE SYSTEM (1)').limit(count)
+    @result = Clue.from('"clues" TABLESAMPLE SYSTEM (100)').limit(count)
 
     #@result = Clue.order(Arel.sql('RANDOM()')).limit(count)
     respond_to do |format|


### PR DESCRIPTION
The `TABLESAMPLE` query added in commit 0876b63 samples only 1% of the table instead of 100%. Right now if you go to https://jservice.io and get some random questions, the airdate is always before 1990.

In the [PostgreSQL documentation for SELECT](https://www.postgresql.org/docs/current/sql-select.html), the section for `TABLESAMPLE` says the argument 

> is the fraction of the table to sample, expressed as a percentage between 0 and 100. 

And the [TABLESAMPLE Implementation page on the PostgreSQL Wiki](https://wiki.postgresql.org/wiki/TABLESAMPLE_Implementation#Project_Details) gives these details:

> ```
> <sample clause> ::= TABLESAMPLE <sample method> <left paren> 
>                     <sample percentage> <right paren> [ <repeatable clause> ]
> ```
> ...
> [Let] S be the value of `<sample percentage>`.
> ...
> [The] result...is a table containing approximately (N ∗ S/100) rows of RT. The probability of a row of RT being included in result of TF is S/100.