### PR TITLE
Removed "Jeppy - 6 Question Jeopardy Game" as this is not available a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,3 @@ View a working demo at http://jservice.io
 * [jApi - ruby gem for jService](https://github.com/djds23/jApi)
 * [Hip Trivia for HipChat](https://github.com/aarontam/hip-trivia)
 * [Flashcard Jeopardy!](https://codepen.io/DesmondW/full/ExZexOV)
-* [Jeppy - 6 Question Jeopardy Game](http://jeppy.herokuapp.com)


### PR DESCRIPTION
When opened "Jeppy - 6 Question Jeopardy Game" it is showing "Application error" which is kinda frustating or sad to see that the App isn't available anymore.
Maybe Founder of this game created their new app listed in [Jservice in wild](https://github.com/sottenad/jService#jservice-in-the-wild) or maybe as heroku removed free trier apps from their platform and only allow paid apps, this might be the case that Founder of **[Jeppy - 6 Question Jeopardy Game](http://jeppy.herokuapp.com/)** may have decided to take it down.

_Note: I am not the creater/founder of "Jeppy - 6 Question Jeopardy Game"._